### PR TITLE
BUG: fix import paths, mainly for tests, move example

### DIFF
--- a/statsmodels/sandbox/examples/gam_example.py
+++ b/statsmodels/sandbox/examples/gam_example.py
@@ -1,7 +1,7 @@
 import numpy as np
 import matplotlib.pyplot as plt
-from smooth_basis import make_poly_basis, make_bsplines_basis
-from gam import GamPenalty, LogitGam, GLMGam, MultivariateGamPenalty
+from statsmodels.sandbox.gam_gsoc2015.smooth_basis import make_poly_basis, make_bsplines_basis
+from statsmodels.sandbox.gam_gsoc2015.gam import GamPenalty, LogitGam, GLMGam, MultivariateGamPenalty
 import statsmodels.api as sm
 
 sigmoid = np.vectorize(lambda x: 1.0/(1.0 + np.exp(-x)))
@@ -10,8 +10,8 @@ sigmoid = np.vectorize(lambda x: 1.0/(1.0 + np.exp(-x)))
 n = 100
 
 # make the data
-x = np.linspace(-10, 10, n)   
-y = 1/(1 + np.exp(-x*x)) 
+x = np.linspace(-10, 10, n)
+y = 1/(1 + np.exp(-x*x))
 mu = y.mean()
 y[y > mu] = 1
 y[y < mu] = 0
@@ -30,7 +30,7 @@ alphas = [0, 0.1, 1, 10]
 for i, alpha in enumerate(alphas):
     plt.subplot(2, 2, i+1)
     params0 = np.random.normal(0, 1, df)
-    gp = GamPenalty(wts=1, alpha=alpha, cov_der2=cov_der2, der2=der2_basis)    
+    gp = GamPenalty(wts=1, alpha=alpha, cov_der2=cov_der2, der2=der2_basis)
     g = LogitGam(y, basis, penal=gp)
     res_g = g.fit()
     plt.plot(x, sigmoid(np.dot(basis, res_g.params)))
@@ -56,7 +56,7 @@ cov_der2 = np.dot(der2_basis.T, der2_basis)
 for i, alpha in enumerate(alphas):
     gp = GamPenalty(alpha=alpha, der2=der2_basis, cov_der2=cov_der2)
     gam = LogitGam(y, basis, penal = gp)
-    res_gam = gam.fit(method='nm', max_start_irls=0, 
+    res_gam = gam.fit(method='nm', max_start_irls=0,
                       disp=1, maxiter=5000, maxfun=5000)
     plt.subplot(2, 2, i+1)
     plt.plot(x, sigmoid(np.dot(basis, res_gam.params)), 'o')
@@ -68,7 +68,7 @@ plt.show()
 
 # GAM GLM
 
-# y is continuous 
+# y is continuous
 n = 200
 x = np.linspace(-10, 10, n)
 y = x * x + np.random.normal(0, 1, n)
@@ -86,7 +86,7 @@ for i, alpha in enumerate(alphas):
     # train the model
     gp = GamPenalty(alpha=alpha, cov_der2=cov_der2, der2=der2_basis)
     glm_gam = GLMGam(y, basis, penal = gp)
-    res_glm_gam = glm_gam.fit(method='nm', max_start_irls=0, 
+    res_glm_gam = glm_gam.fit(method='nm', max_start_irls=0,
                               disp=1, maxiter=5000, maxfun=5000)
     plt.plot(x, np.dot(basis, res_glm_gam.params))
     plt.plot(x, y, '.')
@@ -121,7 +121,8 @@ cov_der2 = [np.dot(der2_basis1.T, der2_basis1),
 alpha = [0, 0]
 wts = [1, 1]
 mgp = MultivariateGamPenalty(wts=wts, alphas=alpha, cov_der2=cov_der2,
-                             der2=der2_basis)    
+                             der2=der2_basis)
+
 mLG = LogitGam(y, basis, penal=mgp)
 res_mLG = mLG.fit(maxiter=1000, tol=1e-13)
 
@@ -147,7 +148,8 @@ alpha = [.1, .2]
 wts = [1, 1]
 
 mgp = MultivariateGamPenalty(wts=wts, alphas=alpha, cov_der2=cov_der2,
-                             der2=der2_basis)    
+                             der2=der2_basis)
+
 mLG = LogitGam(y, basis, penal=mgp)
 res_mLG = mLG.fit(maxiter=1000, tol=1e-13)
 

--- a/statsmodels/sandbox/gam_gsoc2015/gam.py
+++ b/statsmodels/sandbox/gam_gsoc2015/gam.py
@@ -3,7 +3,7 @@ import scipy as sp
 from scipy.linalg import block_diag
 from statsmodels.discrete.discrete_model import Logit
 from statsmodels.genmod.generalized_linear_model import GLM, GLMResults
-from smooth_basis import BS
+from .smooth_basis import BS
 from patsy.state import stateful_transform
 
 

--- a/statsmodels/sandbox/gam_gsoc2015/tests/test_gam.py
+++ b/statsmodels/sandbox/gam_gsoc2015/tests/test_gam.py
@@ -1,11 +1,15 @@
-from smooth_basis import make_poly_basis, make_bsplines_basis
-from gam import GamPenalty, GLMGam, MultivariateGamPenalty, LogitGam
+
+
+import os
+
+from statsmodels.sandbox.gam_gsoc2015.smooth_basis import make_poly_basis, make_bsplines_basis
+from statsmodels.sandbox.gam_gsoc2015.gam import GamPenalty, GLMGam, MultivariateGamPenalty, LogitGam
 import numpy as np
 import pandas as pd
 from statsmodels.genmod.families.family import Gaussian
 from numpy.linalg import norm
 from scipy.linalg import block_diag
-import matplotlib.pyplot as plt
+#import matplotlib.pyplot as plt
 from numpy.testing import assert_allclose
 
 sigmoid = np.vectorize(lambda x: 1.0/(1.0 + np.exp(-x)))
@@ -136,8 +140,9 @@ def test_approximation():
 
 
 def test_gam_glm():
-
-    data_from_r = pd.read_csv('results/prediction_from_mgcv.csv')
+    cur_dir = os.path.dirname(os.path.abspath(__file__))
+    file_path = os.path.join(cur_dir, "results","prediction_from_mgcv.csv")
+    data_from_r = pd.read_csv(file_path)
     # dataset used to train the R model
     x = data_from_r.x
     y = data_from_r.y
@@ -167,8 +172,9 @@ def test_gam_glm():
     return
 
 def test_gam_discrete():
-
-    data_from_r = pd.read_csv('results/prediction_from_mgcv.csv')
+    cur_dir = os.path.dirname(os.path.abspath(__file__))
+    file_path = os.path.join(cur_dir, "results","prediction_from_mgcv.csv")
+    data_from_r = pd.read_csv(file_path)
     # dataset used to train the R model
     x = data_from_r.x
     y = data_from_r.ybin

--- a/statsmodels/sandbox/gam_gsoc2015/tests/test_smooth_basis.py
+++ b/statsmodels/sandbox/gam_gsoc2015/tests/test_smooth_basis.py
@@ -1,7 +1,9 @@
-from patsy.state import stateful_transform
+
 import numpy as np
-from smooth_basis import make_poly_basis, make_bsplines_basis
-from smooth_basis import BS
+from patsy.state import stateful_transform
+from statsmodels.sandbox.gam_gsoc2015.smooth_basis import (make_poly_basis, 
+                                                           make_bsplines_basis, BS)
+
 
 def test_make_basis():
     bs = stateful_transform(BS)


### PR DESCRIPTION
after this the unit tests run

I'm running nosetests from outside the sourcetree, e.g.

`M:\Notes>nosetests M:\josef_new\eclipse_ws\statsmodels\statsmodels_py34\statsmod
els\sandbox\gam_gsoc2015\tests`

Also, this moves the example file to the sandbox/examples directory because we cannot run modules inside the source tree with absolute or relative import paths.
`sandbox/examples` doesn't have a `__init__.py` file and is not on the python path with the statsmodels source.
